### PR TITLE
Updated cli to allow for the use of other package managers besides just npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "start": "node dist/cli.js",
     "test": "jest"
   },
   "jest": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,7 +72,7 @@ program
         cloneArgs.push(...template.options);
       }
       cloneArgs.push(templateRepoUrl, projectPath);
-      await execa('git', cloneArgs);
+      await execa('git', cloneArgs, { stdio: 'inherit' });
       console.log('✅ Template cloned successfully.');
 
       // Remove the .git folder from the *new* project
@@ -128,9 +128,10 @@ program
         console.log('ℹ️ No package.json found in template, skipping customization.');
       }
 
+      const packageManager = template.packageManager || "npm";
       // Install dependencies
       console.log('📦 Installing dependencies... (This may take a moment)');
-      await execa('npm', ['install'], { cwd: projectPath });
+      await execa(packageManager, ['install'], { cwd: projectPath, stdio: 'inherit' });
       console.log('✅ Dependencies installed.');
 
       // Let the user know the project was created successfully

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -2,18 +2,21 @@ const templates = [
     {
         name: "starter",
         description: "A starter template for Patternfly react typescript project",
-        repo: "https://github.com/patternfly/patternfly-react-seed.git"
+        repo: "https://github.com/patternfly/patternfly-react-seed.git",
+        packageManager: "yarn"
     },
     {
         name: "compass-starter",
         description: "A starter template for Patternfly compass theme typescript project",
         repo: "https://github.com/patternfly/patternfly-react-seed.git",
-        options: ["--single-branch", "--branch", "compass_theme"]
+        options: ["--single-branch", "--branch", "compass_theme"],
+        packageManager: "yarn"
     },
     {
         name: "nextjs-starter",
         description: "A starter template for Patternfly nextjs project",
-        repo: "git@github.com:patternfly/patternfly-nextjs-seed.git"
+        repo: "git@github.com:patternfly/patternfly-nextjs-seed.git",
+        packageManager: "yarn"
     },
     {
         name: "ai_enabled_starter",


### PR DESCRIPTION
Some projects require the use of yarn, pnpm, etc instead of npm to build and install. This update allows for the use of different package mangers via the use of the packageManager config in the template file.