### PR TITLE
feat: Add base path option for GitHub Pages deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -120,7 +120,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1806,7 +1805,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2757,7 +2755,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2848,7 +2845,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3092,7 +3088,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3471,7 +3466,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -4529,7 +4523,6 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5950,7 +5943,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7824,7 +7816,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -10039,7 +10030,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13148,7 +13138,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14607,7 +14596,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14817,7 +14805,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/__tests__/gh-pages.test.ts
+++ b/src/__tests__/gh-pages.test.ts
@@ -3,6 +3,7 @@ jest.mock('fs-extra', () => ({
   default: {
     pathExists: jest.fn(),
     readJson: jest.fn(),
+    copy: jest.fn(),
   },
 }));
 
@@ -26,10 +27,15 @@ import path from 'path';
 import fs from 'fs-extra';
 import { execa } from 'execa';
 import ghPages from 'gh-pages';
-import { runDeployToGitHubPages } from '../gh-pages.js';
+import {
+  getGitHubPagesPublicPath,
+  normalizeDeployBasePath,
+  runDeployToGitHubPages,
+} from '../gh-pages.js';
 
 const mockPathExists = fs.pathExists as jest.MockedFunction<typeof fs.pathExists>;
 const mockReadJson = fs.readJson as jest.MockedFunction<typeof fs.readJson>;
+const mockCopy = fs.copy as jest.MockedFunction<typeof fs.copy>;
 const mockExeca = execa as jest.MockedFunction<typeof execa>;
 const mockGhPagesPublish = ghPages.publish as jest.MockedFunction<typeof ghPages.publish>;
 
@@ -38,7 +44,11 @@ const cwd = '/tmp/my-app';
 /** Setup pathExists to return values based on path (avoids brittle call-order chains) */
 function setupPathExists(checks: Record<string, boolean>) {
   mockPathExists.mockImplementation((p: string) => {
+    if (p.endsWith(`${path.sep}404.html`) || p.endsWith('/404.html')) {
+      return Promise.resolve(checks['404.html'] ?? false);
+    }
     for (const [key, value] of Object.entries(checks)) {
+      if (key === '404.html') continue;
       if (p.includes(key) || p === path.join(cwd, key)) return Promise.resolve(value);
     }
     return Promise.resolve(checks['*'] ?? false);
@@ -54,6 +64,22 @@ describe('runDeployToGitHubPages', () => {
 
   afterAll(() => {
     consoleLogSpy.mockRestore();
+  });
+
+  describe('getGitHubPagesPublicPath / normalizeDeployBasePath', () => {
+    it('uses root for user GitHub Pages repo', () => {
+      expect(getGitHubPagesPublicPath('octocat', 'octocat.github.io')).toBe('/');
+    });
+
+    it('uses /repo/ for project pages', () => {
+      expect(getGitHubPagesPublicPath('octocat', 'Hello-World')).toBe('/Hello-World/');
+    });
+
+    it('normalizes base path overrides', () => {
+      expect(normalizeDeployBasePath('/')).toBe('/');
+      expect(normalizeDeployBasePath('my-app')).toBe('/my-app/');
+      expect(normalizeDeployBasePath('/my-app')).toBe('/my-app/');
+    });
   });
 
   it('throws when package.json does not exist', async () => {
@@ -108,6 +134,7 @@ describe('runDeployToGitHubPages', () => {
       exitCode: 0,
     } as Awaited<ReturnType<typeof execa>>);
     mockGhPagesPublish.mockImplementation((_dir, _opts, cb) => cb(null));
+    mockCopy.mockResolvedValue(undefined);
 
     await runDeployToGitHubPages(cwd, { skipBuild: false });
 
@@ -115,7 +142,12 @@ describe('runDeployToGitHubPages', () => {
     expect(mockExeca).toHaveBeenNthCalledWith(2, 'npm', ['run', 'build'], {
       cwd,
       stdio: 'inherit',
+      env: expect.objectContaining({ ASSET_PATH: '/repo/' }),
     });
+    expect(mockCopy).toHaveBeenCalledWith(
+      path.join(cwd, 'dist', 'index.html'),
+      path.join(cwd, 'dist', '404.html')
+    );
     expect(mockGhPagesPublish).toHaveBeenCalledWith(
       path.join(cwd, 'dist'),
       { branch: 'gh-pages', repo: 'https://github.com/user/repo.git' },
@@ -140,13 +172,34 @@ describe('runDeployToGitHubPages', () => {
       exitCode: 0,
     } as Awaited<ReturnType<typeof execa>>);
     mockGhPagesPublish.mockImplementation((_dir, _opts, cb) => cb(null));
+    mockCopy.mockResolvedValue(undefined);
 
     await runDeployToGitHubPages(cwd, { skipBuild: false });
 
-    expect(mockExeca).toHaveBeenNthCalledWith(2, 'yarn', ['build'], {
+    expect(mockExeca).toHaveBeenNthCalledWith(2, 'yarn', ['run', 'build'], {
       cwd,
       stdio: 'inherit',
+      env: expect.objectContaining({ ASSET_PATH: '/repo/' }),
     });
+  });
+
+  it('does not set ASSET_PATH for <user>.github.io repository (site root)', async () => {
+    setupPathExists({ 'package.json': true, 'dist': true });
+    mockReadJson.mockResolvedValueOnce({
+      scripts: { build: 'webpack --config webpack.prod.js' },
+    });
+    mockExeca.mockResolvedValue({
+      stdout: 'https://github.com/octocat/octocat.github.io.git',
+      stderr: '',
+      exitCode: 0,
+    } as Awaited<ReturnType<typeof execa>>);
+    mockGhPagesPublish.mockImplementation((_dir, _opts, cb) => cb(null));
+    mockCopy.mockResolvedValue(undefined);
+
+    await runDeployToGitHubPages(cwd, { skipBuild: false });
+
+    const buildOpts = mockExeca.mock.calls[1][2] as { env?: NodeJS.ProcessEnv };
+    expect(buildOpts.env?.ASSET_PATH).toBeUndefined();
   });
 
   it('uses pnpm when pnpm-lock.yaml exists (and no yarn.lock)', async () => {
@@ -160,12 +213,14 @@ describe('runDeployToGitHubPages', () => {
       exitCode: 0,
     } as Awaited<ReturnType<typeof execa>>);
     mockGhPagesPublish.mockImplementation((_dir, _opts, cb) => cb(null));
+    mockCopy.mockResolvedValue(undefined);
 
     await runDeployToGitHubPages(cwd, { skipBuild: false });
 
-    expect(mockExeca).toHaveBeenNthCalledWith(2, 'pnpm', ['build'], {
+    expect(mockExeca).toHaveBeenNthCalledWith(2, 'pnpm', ['run', 'build', '--', '--base', '/repo/'], {
       cwd,
       stdio: 'inherit',
+      env: expect.objectContaining({ ASSET_PATH: '/repo/' }),
     });
   });
 
@@ -177,6 +232,7 @@ describe('runDeployToGitHubPages', () => {
       exitCode: 0,
     } as Awaited<ReturnType<typeof execa>>);
     mockGhPagesPublish.mockImplementation((_dir, _opts, cb) => cb(null));
+    mockCopy.mockResolvedValue(undefined);
 
     await runDeployToGitHubPages(cwd, { skipBuild: true });
 
@@ -228,6 +284,7 @@ describe('runDeployToGitHubPages', () => {
       exitCode: 0,
     } as Awaited<ReturnType<typeof execa>>);
     mockGhPagesPublish.mockImplementation((_dir, _opts, cb) => cb(null));
+    mockCopy.mockResolvedValue(undefined);
 
     await runDeployToGitHubPages(cwd, {
       skipBuild: true,
@@ -271,6 +328,7 @@ describe('runDeployToGitHubPages', () => {
       stderr: '',
       exitCode: 0,
     } as Awaited<ReturnType<typeof execa>>);
+    mockCopy.mockResolvedValue(undefined);
     mockGhPagesPublish.mockImplementation((_dir, _opts, cb) =>
       cb(new Error('Deploy failed'))
     );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -143,6 +143,10 @@ program
   .option('-d, --dist-dir <dir>', 'Build output directory to deploy', 'dist')
   .option('--no-build', 'Skip running the build step (deploy existing output only)')
   .option('-b, --branch <branch>', 'Git branch to deploy to', 'gh-pages')
+  .option(
+    '--base <path>',
+    'Public URL path for assets (default: /<repo>/ from git origin, or / for <user>.github.io repos)'
+  )
   .action(async (projectPath, options) => {
     const cwd = projectPath ? path.resolve(projectPath) : process.cwd();
     try {
@@ -150,6 +154,7 @@ program
         distDir: options.distDir,
         skipBuild: options.build === false,
         branch: options.branch,
+        basePath: options.base,
       });
     } catch (error) {
       if (error instanceof Error) {

--- a/src/gh-pages.ts
+++ b/src/gh-pages.ts
@@ -11,6 +11,11 @@ export type DeployOptions = {
   skipBuild: boolean;
   /** Branch to push to (default gh-pages) */
   branch: string;
+  /**
+   * Public path prefix for the site (e.g. "/" or "/my-repo/").
+   * When omitted, derived from origin: project pages use "/<repo>/", user pages use "/".
+   */
+  basePath?: string;
 };
 
 const DEFAULT_DIST_DIR = 'dist';
@@ -32,6 +37,88 @@ function parseRepoFromUrl(repoUrl: string): { owner: string; repo: string } | nu
     return { owner: httpsMatch[1], repo: httpsMatch[2] };
   }
   return null;
+}
+
+/**
+ * Path prefix for static assets on GitHub Pages.
+ * User/org sites use repo "<owner>.github.io" and are served from "/".
+ * Project sites are served from "/<repo>/".
+ */
+export function getGitHubPagesPublicPath(owner: string, repo: string): string {
+  const repoLower = repo.toLowerCase();
+  const ownerLower = owner.toLowerCase();
+  if (repoLower === `${ownerLower}.github.io`) {
+    return '/';
+  }
+  const repoSegment = repo.replace(/\.git$/i, '');
+  return `/${repoSegment}/`;
+}
+
+/**
+ * Normalize CLI/base override: "/" or "" → root; otherwise ensure leading and trailing "/".
+ */
+export function normalizeDeployBasePath(input: string): string {
+  const t = input.trim();
+  if (t === '' || t === '/') {
+    return '/';
+  }
+  let s = t.startsWith('/') ? t : `/${t}`;
+  if (!s.endsWith('/')) {
+    s = `${s}/`;
+  }
+  return s;
+}
+
+function resolvePublicPathFromRemote(repoUrl: string): string {
+  const parsed = parseRepoFromUrl(repoUrl);
+  if (!parsed) {
+    return '/';
+  }
+  return getGitHubPagesPublicPath(parsed.owner, parsed.repo);
+}
+
+type PkgJson = {
+  scripts?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
+
+/**
+ * Build-time flags for common React toolchains on GitHub Pages.
+ */
+function getGithubPagesBuildArgs(
+  pkg: PkgJson,
+  publicPath: string
+): { env: Record<string, string>; extraArgs: string[] } {
+  const buildScript = pkg.scripts?.['build'] ?? '';
+  const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+  const env: Record<string, string> = {};
+  const extraArgs: string[] = [];
+
+  if (publicPath !== '/') {
+    // patternfly-react-seed webpack (and similar) uses ASSET_PATH for output.publicPath
+    env['ASSET_PATH'] = publicPath;
+  }
+  if (publicPath !== '/' && deps['react-scripts']) {
+    env['PUBLIC_URL'] = publicPath;
+  }
+  if (publicPath !== '/' && /\bvite\b/.test(buildScript)) {
+    extraArgs.push('--base', publicPath);
+  }
+
+  return { env, extraArgs };
+}
+
+/**
+ * GitHub Pages returns 404 for unknown paths; copy index.html so SPA refreshes on deep links work.
+ */
+async function ensureSpa404Html(distDir: string): Promise<void> {
+  const indexHtml = path.join(distDir, 'index.html');
+  const notFoundHtml = path.join(distDir, '404.html');
+  if ((await fs.pathExists(indexHtml)) && !(await fs.pathExists(notFoundHtml))) {
+    await fs.copy(indexHtml, notFoundHtml);
+    console.log('   Added 404.html (copy of index.html) for client-side route refreshes on GitHub Pages.');
+  }
 }
 
 /**
@@ -87,22 +174,28 @@ async function getPackageManager(cwd: string): Promise<'yarn' | 'pnpm' | 'npm'> 
 
 /**
  * Run build script in the project (npm run build / yarn build / pnpm build).
+ * Sets ASSET_PATH / PUBLIC_URL / Vite --base when publicPath is not "/" so assets resolve on project pages.
  */
-async function runBuild(cwd: string): Promise<void> {
+async function runBuild(cwd: string, publicPath: string): Promise<void> {
   const pkgPath = path.join(cwd, 'package.json');
-  const pkg = await fs.readJson(pkgPath);
-  const scripts = (pkg.scripts as Record<string, string>) || {};
+  const pkg = (await fs.readJson(pkgPath)) as PkgJson;
+  const scripts = pkg.scripts || {};
   if (!scripts['build']) {
     throw new Error(
       'No "build" script found in package.json. Add a build script or use --no-build and deploy an existing folder with -d/--dist-dir.'
     );
   }
 
+  const { env: ghEnv, extraArgs } = getGithubPagesBuildArgs(pkg, publicPath);
+  const env = Object.keys(ghEnv).length ? { ...process.env, ...ghEnv } : process.env;
+
   const pm = await getPackageManager(cwd);
   const runCmd = pm === 'npm' ? 'npm' : pm === 'yarn' ? 'yarn' : 'pnpm';
-  const args = pm === 'npm' ? ['run', 'build'] : ['build'];
-  console.log(`📦 Running build (${runCmd} ${args.join(' ')})...`);
-  await execa(runCmd, args, { cwd, stdio: 'inherit' });
+  const args = ['run', 'build', ...(extraArgs.length > 0 ? ['--', ...extraArgs] : [])];
+  const envNote =
+    publicPath !== '/' ? ` (GitHub Pages base: ${publicPath})` : '';
+  console.log(`📦 Running build (${runCmd} ${args.join(' ')})${envNote}...`);
+  await execa(runCmd, args, { cwd, stdio: 'inherit', env });
   console.log('✅ Build completed.\n');
 }
 
@@ -140,8 +233,11 @@ export async function runDeployToGitHubPages(
     );
   }
 
+  const publicPath =
+    options.basePath !== undefined ? normalizeDeployBasePath(options.basePath) : resolvePublicPathFromRemote(repoUrl);
+
   if (!skipBuild) {
-    await runBuild(cwd);
+    await runBuild(cwd, publicPath);
   }
 
   const absoluteDist = path.join(cwd, distDir);
@@ -150,6 +246,8 @@ export async function runDeployToGitHubPages(
       `Build output directory "${distDir}" does not exist. Run a build first or specify the correct directory with -d/--dist-dir.`
     );
   }
+
+  await ensureSpa404Html(absoluteDist);
 
   const parsed = parseRepoFromUrl(repoUrl);
   if (parsed) {
@@ -166,5 +264,11 @@ export async function runDeployToGitHubPages(
   });
   console.log('\n✅ Deployed to GitHub Pages.');
   console.log('   Enable GitHub Pages in your repo: Settings → Pages → Source: branch "' + branch + '".');
-  console.log('   If the site is at username.github.io/<repo-name>, set your app\'s base path (e.g. base: \'/<repo-name>/\' in Vite).\n');
+  if (publicPath !== '/') {
+    const basename = publicPath.replace(/\/$/, '');
+    console.log(
+      `   React Router: use <BrowserRouter basename="${basename}"> (or equivalent) so routes match ${publicPath}.`
+    );
+  }
+  console.log('');
 }


### PR DESCRIPTION
- Introduced a new CLI option `--base` to specify the public URL path for assets.
- Updated deployment logic to handle base path for GitHub Pages.
- Added utility functions to normalize base paths and determine public paths based on repository type.
- Enhanced tests to cover new functionality and ensure correct behavior for different repository setups.