### PR TITLE
fix: Updated to tell user github pages site location.

### DIFF
--- a/src/__tests__/gh-pages.test.ts
+++ b/src/__tests__/gh-pages.test.ts
@@ -29,6 +29,7 @@ import { execa } from 'execa';
 import ghPages from 'gh-pages';
 import {
   getGitHubPagesPublicPath,
+  getGitHubPagesSiteUrl,
   normalizeDeployBasePath,
   runDeployToGitHubPages,
 } from '../gh-pages.js';
@@ -73,6 +74,16 @@ describe('runDeployToGitHubPages', () => {
 
     it('uses /repo/ for project pages', () => {
       expect(getGitHubPagesPublicPath('octocat', 'Hello-World')).toBe('/Hello-World/');
+    });
+
+    it('builds HTTPS site URL for project pages', () => {
+      expect(getGitHubPagesSiteUrl('octocat', 'Hello-World')).toBe(
+        'https://octocat.github.io/Hello-World/'
+      );
+    });
+
+    it('builds HTTPS site URL for user/org pages repo', () => {
+      expect(getGitHubPagesSiteUrl('octocat', 'octocat.github.io')).toBe('https://octocat.github.io/');
     });
 
     it('normalizes base path overrides', () => {
@@ -158,6 +169,9 @@ describe('runDeployToGitHubPages', () => {
     );
     expect(consoleLogSpy).toHaveBeenCalledWith(
       expect.stringContaining('Deployed to GitHub Pages')
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('https://user.github.io/repo/')
     );
   });
 

--- a/src/gh-pages.ts
+++ b/src/gh-pages.ts
@@ -55,6 +55,20 @@ export function getGitHubPagesPublicPath(owner: string, repo: string): string {
 }
 
 /**
+ * Public HTTPS URL for the site on GitHub Pages (user/org pages vs project pages).
+ */
+export function getGitHubPagesSiteUrl(owner: string, repo: string): string {
+  const repoSegment = repo.replace(/\.git$/i, '');
+  const repoLower = repoSegment.toLowerCase();
+  const ownerLower = owner.toLowerCase();
+  const host = `${ownerLower}.github.io`;
+  if (repoLower === `${ownerLower}.github.io`) {
+    return `https://${host}/`;
+  }
+  return `https://${host}/${repoSegment}/`;
+}
+
+/**
  * Normalize CLI/base override: "/" or "" → root; otherwise ensure leading and trailing "/".
  */
 export function normalizeDeployBasePath(input: string): string {
@@ -263,6 +277,11 @@ export async function runDeployToGitHubPages(
     );
   });
   console.log('\n✅ Deployed to GitHub Pages.');
+  if (parsed) {
+    const siteUrl = getGitHubPagesSiteUrl(parsed.owner, parsed.repo);
+    console.log(`🌐 Your site: ${siteUrl}`);
+    console.log('   (URL may take a minute to update after the first deploy.)\n');
+  }
   console.log('   Enable GitHub Pages in your repo: Settings → Pages → Source: branch "' + branch + '".');
   if (publicPath !== '/') {
     const basename = publicPath.replace(/\/$/, '');


### PR DESCRIPTION
Updated to inform the user where there site is located after a github pages deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GitHub Pages deployment now displays the public HTTPS site URL in console output for both user/organization and project pages.

* **Tests**
  * Added test coverage for GitHub Pages URL generation and deployment output validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->