### PR TITLE
fix: Fixes issue with patternfly-starter seed is not building.

### DIFF
--- a/src/__tests__/create.test.ts
+++ b/src/__tests__/create.test.ts
@@ -152,7 +152,7 @@ describe('runCreate', () => {
     expect(mockExeca).toHaveBeenNthCalledWith(
       1,
       'git',
-      ['clone', starter!.repo, projectPath],
+      ['clone', ...(starter!.options ?? []), starter!.repo, projectPath],
       expect.objectContaining({ stdio: 'inherit' })
     );
   });
@@ -166,7 +166,7 @@ describe('runCreate', () => {
     expect(mockExeca).toHaveBeenNthCalledWith(
       1,
       'git',
-      ['clone', starter!.repoSSH, projectPath],
+      ['clone', ...(starter!.options ?? []), starter!.repoSSH, projectPath],
       expect.objectContaining({ stdio: 'inherit' })
     );
   });
@@ -225,7 +225,7 @@ describe('runCreate', () => {
 
     expect(mockExeca).toHaveBeenNthCalledWith(
       2,
-      'yarn',
+      'npm',
       ['install'],
       expect.objectContaining({ cwd: projectPath, stdio: 'inherit' })
     );

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -19,7 +19,8 @@ export const defaultTemplates: Template[] = [
         description: "A starter template for Patternfly react typescript project",
         repo: "https://github.com/patternfly/patternfly-react-seed.git",
         repoSSH: "git@github.com:patternfly/patternfly-react-seed.git",
-        packageManager: "yarn"
+        options: ["--single-branch", "--branch", "main"],
+        packageManager: "npm"
     },
     {
         name: "compass-starter",


### PR DESCRIPTION
This fixes the bug where the PatternFly seed (starter selection when creating a project) does not build. Closes jira issue #4007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Starter template now uses npm as the default package manager instead of yarn.
  * Git clone behavior improved to perform a single-branch checkout of the main branch and consistently include checkout options when cloning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->